### PR TITLE
reset the search engine on the about:home page

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -3,7 +3,6 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var Cu = Components.utils;
-var DEBUG = 0;
 
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/AddonManager.jsm");
@@ -11,28 +10,32 @@ Cu.import("resource://gre/modules/AddonManager.jsm");
 function startup(aData, aReason) {
   // Helper function that backs up and then clears a pref, if it has a user-set
   // value.
+
   function resetPref(prefName) {
-    if (Services.prefs.prefIsLocked(prefName)){
-      if (DEBUG) Services.prompt.alert(null, "RESET", "LOCKED: "+prefName);
-    }
+    let status = "";
+    if (Services.prefs.prefIsLocked(prefName) && DEBUG) status = "\n(LOCKED)";
 
     if (Services.prefs.prefHasUserValue(prefName)) {
       var existingValue = Services.prefs.getCharPref(prefName);
       Services.prefs.setCharPref("searchreset.backup." + prefName, existingValue);
 
       Services.prefs.clearUserPref(prefName);
+
+      if (DEBUG) status = "\n\nold: " + existingValue;
     }
+
+    if (DEBUG) Services.prompt.alert(null, "RESET", prefName + status + "\ncur: " + Services.prefs.getCharPref(prefName));
   }
 
   // Reset the home page and keyword.URL
-  resetPref("browser.startup.homepage");
+  resetPref("browser.startup.homepage"); // complex value
   resetPref("keyword.URL");
 
   // Reset the New Tab Page
   resetPref("browser.newtab.url");
 
   // Now also reset the default search engine
-  resetPref("browser.search.defaultenginename");
+  resetPref("browser.search.defaultenginename");  // complex value
 
   let originalDefaultEngine = Services.search.originalDefaultEngine;
 
@@ -40,19 +43,12 @@ function startup(aData, aReason) {
     originalDefaultEngine.hidden = false;
     Services.search.currentEngine = originalDefaultEngine;
     Services.search.moveEngine(originalDefaultEngine, 0);
-  } else if (DEBUG) Services.prompt.alert(null, "ERROR", "NO originalDefaultEngine");
-  
-  // Flush changes to disk
-  Services.prefs.savePrefFile(null);
 
-  // reset the search engine used on the about:home page
-  // code reused from AboutHomeUtils
-  // http://mxr.mozilla.org/mozilla-central/source/browser/components/nsBrowserContentHandler.js#838
-  let defaultEngine = Services.search.originalDefaultEngine;
-
-  if (defaultEngine) {
-    let submission = defaultEngine.getSubmission("_searchTerms_");
-    let engine = {name: defaultEngine.name, searchUrl: submission.uri.spec};
+    // reset the search engine used on the about:home page
+    // code reused from AboutHomeUtils
+    // http://mxr.mozilla.org/mozilla-central/source/browser/components/nsBrowserContentHandler.js#838
+    let submission = originalDefaultEngine.getSubmission("_searchTerms_");
+    let engine = {name: originalDefaultEngine.name, searchUrl: submission.uri.spec};
     let aboutHomeURI = Services.io.newURI("moz-safe-about:home", null, null);
 
     try {
@@ -62,8 +58,11 @@ function startup(aData, aReason) {
       let dsm = Components.classes["@mozilla.org/dom/storagemanager;1"].getService(Components.interfaces.nsIDOMStorageManager);
 
       dsm.getLocalStorageForPrincipal(principal, "").setItem("search-engine", JSON.stringify(engine));
-     } catch(e) { if (DEBUG) Services.prompt.alert(null, "ERROR resetting about:home" ,e); }
-  } else if (DEBUG) Services.prompt.alert(null, "ERROR", "NO defaultEngine");
+     } catch(e) { if (DEBUG) Services.prompt.alert(null, "ERROR resetting about:home" ,e); }    
+  } else if (DEBUG) Services.prompt.alert(null, "ERROR", "NO originalDefaultEngine");
+  
+  // Flush changes to disk
+  Services.prefs.savePrefFile(null);
 
   // auto-uninstall after running
   AddonManager.getAddonByID(aData.id, function(addon) {
@@ -76,3 +75,4 @@ function shutdown(aData, aReason) { }
 function install(aData, aReason) { }
 
 function uninstall(aData, aReason) { }
+

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -3,6 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 var Cu = Components.utils;
+var DEBUG = 0;
 
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/AddonManager.jsm");
@@ -11,6 +12,10 @@ function startup(aData, aReason) {
   // Helper function that backs up and then clears a pref, if it has a user-set
   // value.
   function resetPref(prefName) {
+    if (Services.prefs.prefIsLocked(prefName)){
+      if (DEBUG) Services.prompt.alert(null, "RESET", "LOCKED: "+prefName);
+    }
+
     if (Services.prefs.prefHasUserValue(prefName)) {
       var existingValue = Services.prefs.getCharPref(prefName);
       Services.prefs.setCharPref("searchreset.backup." + prefName, existingValue);
@@ -28,11 +33,15 @@ function startup(aData, aReason) {
 
   // Now also reset the default search engine
   resetPref("browser.search.defaultenginename");
-  let originalDefaultEngine = Services.search.originalDefaultEngine;
-  originalDefaultEngine.hidden = false;
-  Services.search.currentEngine = originalDefaultEngine;
-  Services.search.moveEngine(originalDefaultEngine, 0);
 
+  let originalDefaultEngine = Services.search.originalDefaultEngine;
+
+  if (originalDefaultEngine) {
+    originalDefaultEngine.hidden = false;
+    Services.search.currentEngine = originalDefaultEngine;
+    Services.search.moveEngine(originalDefaultEngine, 0);
+  } else if (DEBUG) Services.prompt.alert(null, "ERROR", "NO originalDefaultEngine");
+  
   // Flush changes to disk
   Services.prefs.savePrefFile(null);
 
@@ -40,18 +49,21 @@ function startup(aData, aReason) {
   // code reused from AboutHomeUtils
   // http://mxr.mozilla.org/mozilla-central/source/browser/components/nsBrowserContentHandler.js#838
   let defaultEngine = Services.search.originalDefaultEngine;
-  let submission = defaultEngine.getSubmission("_searchTerms_");
-  let engine = {name: defaultEngine.name, searchUrl: submission.uri.spec};
-  let aboutHomeURI = Services.io.newURI("moz-safe-about:home", null, null);
 
-	try {
-	let ssm = Components.classes["@mozilla.org/scriptsecuritymanager;1"].getService(Components.interfaces.nsIScriptSecurityManager);
-  let principal = (ssm.getCodebasePrincipal || ssm.getNoAppCodebasePrincipal)(aboutHomeURI);
+  if (defaultEngine) {
+    let submission = defaultEngine.getSubmission("_searchTerms_");
+    let engine = {name: defaultEngine.name, searchUrl: submission.uri.spec};
+    let aboutHomeURI = Services.io.newURI("moz-safe-about:home", null, null);
 
-  let dsm = Components.classes["@mozilla.org/dom/storagemanager;1"].getService(Components.interfaces.nsIDOMStorageManager);
+    try {
+      let ssm = Components.classes["@mozilla.org/scriptsecuritymanager;1"].getService(Components.interfaces.nsIScriptSecurityManager);
+      let principal = (ssm.getCodebasePrincipal || ssm.getNoAppCodebasePrincipal)(aboutHomeURI);
 
-	dsm.getLocalStorageForPrincipal(principal, "").setItem("search-engine", JSON.stringify(engine));
-	} catch(e) { Services.prompt.alert(null, e, "Error resetting about:home"); }
+      let dsm = Components.classes["@mozilla.org/dom/storagemanager;1"].getService(Components.interfaces.nsIDOMStorageManager);
+
+      dsm.getLocalStorageForPrincipal(principal, "").setItem("search-engine", JSON.stringify(engine));
+     } catch(e) { if (DEBUG) Services.prompt.alert(null, "ERROR resetting about:home" ,e); }
+  } else if (DEBUG) Services.prompt.alert(null, "ERROR", "NO defaultEngine");
 
   // auto-uninstall after running
   AddonManager.getAddonByID(aData.id, function(addon) {


### PR DESCRIPTION
I have added the code to bootstrap.js as proposed in the SUMO contributors forum
https://support.mozilla.org/forums/contributors/708557#post-48144

I have added a try and catch with an alert just in case because they have changed getCodebasePrincipal to getNoAppCodebasePrincipal in Firefox 17
