### PR TITLE
added resetPref("browser.newtabpage.enabled");

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -25,6 +25,7 @@ function startup(aData, aReason) {
 
   // Reset the New Tab Page
   resetPref("browser.newtab.url");
+  resetPref("browser.newtabpage.enabled");
 
   // Now also reset the default search engine
   resetPref("browser.search.defaultenginename");

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -25,8 +25,7 @@ function startup(aData, aReason) {
 
   // Reset the New Tab Page
   resetPref("browser.newtab.url");
-  resetPref("browser.newtabpage.enabled");
-
+ 
   // Now also reset the default search engine
   resetPref("browser.search.defaultenginename");
   let originalDefaultEngine = Services.search.originalDefaultEngine;


### PR DESCRIPTION
New proposal that addresses most changes.
Kept "if (originalDefaultEngine) {}" and moved the about:home code under it.
Improved the DEBUG info under resetPref().
browser.startup.homepage and browser.search.defaultenginename are complex values and thus are reset to chrome://browser-region/locale/region.properties

Added resetPref("browser.newtabpage.enabled") to make the new tab page appear in case it was hidden.
